### PR TITLE
fetch only required resources

### DIFF
--- a/src/hydra/parseHydraDocumentation.js
+++ b/src/hydra/parseHydraDocumentation.js
@@ -186,12 +186,13 @@ function findRelatedClass(docs, property) {
  *
  * @param {string} entrypointUrl
  * @param {object} options
+ * @param {array} requiredResources
  * @return {Promise.<Api>}
  */
-export default function parseHydraDocumentation(entrypointUrl, options = {}) {
+export default function parseHydraDocumentation(entrypointUrl, options = {}, requiredResources = []) {
   entrypointUrl = removeTrailingSlash(entrypointUrl);
 
-  return fetchEntrypointAndDocs(entrypointUrl, options).then(
+  return fetchEntrypointAndDocs(entrypointUrl, options, requiredResources).then(
     ({ entrypoint, docs, response }) => {
       const resources = [],
         fields = [],
@@ -232,6 +233,15 @@ export default function parseHydraDocumentation(entrypointUrl, options = {}) {
           '["http://www.w3.org/ns/hydra/core#property"][0]'
         );
         if (!property) {
+          continue;
+        }
+
+        // skip resource if it's not required
+        if (
+          !requiredResources.includes(
+            property["@id"].replace(entrypointClass["@id"] + "/", "")
+          )
+        ) {
           continue;
         }
 

--- a/src/hydra/parseHydraDocumentation.js
+++ b/src/hydra/parseHydraDocumentation.js
@@ -192,7 +192,7 @@ function findRelatedClass(docs, property) {
 export default function parseHydraDocumentation(entrypointUrl, options = {}, requiredResources = []) {
   entrypointUrl = removeTrailingSlash(entrypointUrl);
 
-  return fetchEntrypointAndDocs(entrypointUrl, options, requiredResources).then(
+  return fetchEntrypointAndDocs(entrypointUrl, options).then(
     ({ entrypoint, docs, response }) => {
       const resources = [],
         fields = [],
@@ -236,17 +236,20 @@ export default function parseHydraDocumentation(entrypointUrl, options = {}, req
           continue;
         }
 
+        // Add fields
+        const relatedClass = findRelatedClass(docs, property);
+
         // skip resource if it's not required
+        const relatedClassTitle = get(
+          relatedClass,
+          '["http://www.w3.org/ns/hydra/core#title"][0]["@value"]'
+        );
         if (
-          !requiredResources.includes(
-            property["@id"].replace(entrypointClass["@id"] + "/", "")
-          )
+          requiredResources.length > 0 &&
+          !requiredResources.includes(relatedClassTitle)
         ) {
           continue;
         }
-
-        // Add fields
-        const relatedClass = findRelatedClass(docs, property);
         for (const supportedProperties of relatedClass[
           "http://www.w3.org/ns/hydra/core#supportedProperty"
         ]) {

--- a/src/hydra/parseHydraDocumentation.test.js
+++ b/src/hydra/parseHydraDocumentation.test.js
@@ -1106,6 +1106,16 @@ const expectedApi = {
   resources: resources
 };
 
+const requiredResources = ["Book", "CustomResource"];
+
+const expectedRequiredResources = [book, customResource];
+
+const expectedRequiredResourcesApi = {
+  entrypoint: "http://localhost",
+  title: "API Platform's demo",
+  resources: expectedRequiredResources
+};
+
 const init = {
   status: 200,
   statusText: "OK",
@@ -1134,6 +1144,20 @@ test("parse a Hydra documentation", async () => {
       "http://localhost/docs.jsonld",
       options
     );
+  });
+});
+
+test("parse a Hydra documentation with required resources", async () => {
+  fetch.mockResponses([entrypoint, init], [docs, init]);
+
+  const options = { headers: new Headers({ CustomHeader: "customValue" }) };
+
+  await parseHydraDocumentation("http://localhost", options, requiredResources).then(data => {
+    expect(JSON.stringify(data.api, null, 2)).toBe(
+      JSON.stringify(expectedRequiredResourcesApi, null, 2)
+    );
+    expect(data.response).toBeDefined();
+    expect(data.status).toBe(200);
   });
 });
 


### PR DESCRIPTION
When using the Hydra data provider directly, often only some and not all available resources are needed. 

This adds the possibility to skip the parsing of unneeded resources in "parseHydraDocumentation" via the new parameter "requiredResources".
As a result, API calls can be saved and performance increased.

Here is an example, if e.g. only "Books" and "CustomResource" are used in the admin and "Review" and "DeprecatedResource" are not.
(based on https://api-platform.com/docs/admin/getting-started/#using-the-hydra-data-provider-directly-with-react-admin)

```javascript
[...]

const requiredResources = ["Book", "CustomResource"];

const entrypoint = process.env.REACT_APP_API_ENTRYPOINT;
const fetchHeaders = {'Authorization': `Bearer ${window.localStorage.getItem('token')}`};
const fetchHydra = (url, options = {}) => baseFetchHydra(url, {
    ...options,
    headers: new Headers(fetchHeaders),
});
const dataProvider = api => hydraClient(api, fetchHydra);
const apiDocumentationParser = entrypoint => parseHydraDocumentation(
        entrypoint, 
        { headers: new Headers(fetchHeaders) },
        requiredResources
    )
    .then(
        ({ api }) => ({api}),
        (result) => {
            switch (result.status) {
                case 401:
                    return Promise.resolve({
                        api: result.api,
                        customRoutes: [{
                            props: {
                                path: '/',
                                render: () => <Redirect to={`/login`}/>,
                            },
                        }],
                    });

                default:
                    return Promise.reject(result);
            }
        },
    );

[...]
```